### PR TITLE
Bump minitest to 5.10.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,6 @@ GEM
     byebug (9.0.5)
     coderay (1.1.1)
     method_source (0.8.2)
-    minitest (5.9.1)
     pry (0.10.4)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -24,4 +23,4 @@ DEPENDENCIES
   rake
 
 BUNDLED WITH
-   1.12.5
+   1.13.7


### PR DESCRIPTION
Bumps [minitest](https://github.com/seattlerb/minitest) to 5.10.1.
- [Changelog](https://github.com/seattlerb/minitest/blob/master/History.rdoc)
- [Commits](https://github.com/seattlerb/minitest/commits)