### PR TITLE
Bump rake to 12.0.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,7 +12,6 @@ GEM
     pry-byebug (3.4.0)
       byebug (~> 9.0)
       pry (~> 0.10)
-    rake (11.3.0)
     slop (3.6.0)
 
 PLATFORMS
@@ -24,4 +23,4 @@ DEPENDENCIES
   rake
 
 BUNDLED WITH
-   1.12.5
+   1.13.7


### PR DESCRIPTION
Bumps [rake](https://github.com/ruby/rake) to 12.0.0.
- [Changelog](https://github.com/ruby/rake/blob/master/History.rdoc)
- [Commits](https://github.com/ruby/rake/commits)