### PR TITLE
Bump minitest to 5.10.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,6 @@ source 'https://rubygems.org'
 gem 'pry-byebug', '~> 3.4'
 
 group :test do
-  gem 'minitest', '~> 5.9'
+  gem 'minitest', '~> 5.10'
   gem 'rake', '~> 11.3'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,6 @@ GEM
     byebug (9.0.5)
     coderay (1.1.1)
     method_source (0.8.2)
-    minitest (5.9.1)
     pry (0.10.4)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -19,7 +18,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  minitest (~> 5.9)
+  minitest (~> 5.10)
   pry-byebug (~> 3.4)
   rake (~> 11.3)
 


### PR DESCRIPTION
Bumps [minitest](https://github.com/seattlerb/minitest) to 5.10.1.
- [Changelog](https://github.com/seattlerb/minitest/blob/master/History.rdoc)
- [Commits](https://github.com/seattlerb/minitest/commits)