### PR TITLE
Bump rake to 12.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,5 @@ gem 'pry-byebug', '~> 3.4'
 
 group :test do
   gem 'minitest', '~> 5.9'
-  gem 'rake', '~> 11.3'
+  gem 'rake', '~> 12.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,7 +12,6 @@ GEM
     pry-byebug (3.4.0)
       byebug (~> 9.0)
       pry (~> 0.10)
-    rake (11.3.0)
     slop (3.6.0)
 
 PLATFORMS
@@ -21,7 +20,7 @@ PLATFORMS
 DEPENDENCIES
   minitest (~> 5.9)
   pry-byebug (~> 3.4)
-  rake (~> 11.3)
+  rake (~> 12.0)
 
 BUNDLED WITH
    1.13.7


### PR DESCRIPTION
Bumps [rake](https://github.com/ruby/rake) to 12.0.0.
- [Changelog](https://github.com/ruby/rake/blob/master/History.rdoc)
- [Changes since 11.3.0](https://github.com/ruby/rake/compare/v11.3.0...v12.0.0)